### PR TITLE
Cross-compile to avoid a lot of QEMU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16
+FROM --platform=$BUILDPLATFORM golang:1.16
 LABEL maintainer="Blake Covarrubias <blake@covarrubi.as>" \
       org.opencontainers.image.authors="Blake Covarrubias <blake@covarrubi.as>" \
       org.opencontainers.image.description="Advertises records for Kubernetes resources over multicast DNS." \
@@ -9,11 +9,12 @@ LABEL maintainer="Blake Covarrubias <blake@covarrubi.as>" \
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG TARGETVARIANT
 
 ADD . /go/src/github.com/blake/external-mdns
 WORKDIR /go/src/github.com/blake/external-mdns
 
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=$(echo ${TARGETVARIANT} | cut -c2) \
     go build \
     -ldflags="-s -w" \
     -o external-mdns .


### PR DESCRIPTION
In the interests of getting more target platforms upstream (https://github.com/blake/external-mdns/issues/15).

Leverage Golang's cross-compilation to run compilation natively, but target different architectures. This alleviates the need to run the compiler under emulation of the targets. Effectively, any target runs as fast as the native arch.

```
docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6,linux/arm/v5 .
```

Takes under a minute to run on my Core i7-11700KF.

`TARGETVARIANT` will be `v5/v6/v7` for the above arm targets, but was empty for the rest. I'm unsure about other architectures with variants, but this could be adapted further to only set `GOARM` for arm targets.

If this doesn't work out of the box (buildx seems to cache some arguments), then adding `ARG BUILDPLATFORM` at the top of Dockerfile and `--build-arg BUILDPLATFORM=<arch>` to the command should do the trick, which for me resulted in:

```
docker buildx build --build-arg BUILDPLATFORM=amd64 --platform linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6,linux/arm/v5 .
```