### PR TITLE
[feat] annotations for hostnames and without-namespace for services

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,45 @@ DNS records are advertised with the format `<hostname/service_name>.<namespace>.
 In addition, hostnames for resources in the `-default-namespace` will also be
 advertised with a short name of `<hostname/service_name>.local`.
 
+### Additional control for Services
+
+Service discovery is automatic, however, there are some scenarios where one may wish
+to directly control names used with a more general service i.e. the service might be
+in front of an Ingress Controller but the service you wish to use is not defined with
+an Ingress resource such as in the case of non http/https service with nginx.
+
+Other scenarios include non Ingress types that publish a variety of services and act as
+an ingress but have configurations far more complex than can be expressed by an Ingress
+resource e.g. Istio.
+
+Additionally, one may wish to control in finer detail which services appear directly on
+.local MDNS advertisements without either moving services to the default namespace or
+enabling the global without-namespace flag.
+
+In this case Service annotations are possible as follows - these annotations have no effect
+if applied to an Ingress resource.
+```
+apiVersion: v1
+kind: Service
+metadata:
+  name: myservice
+  namespace: foospace
+  annotations:
+    external-mdns.blakecovarrubias.com/hostnames: foo
+    external-mdns.blakecovarrubias.com/without-namespace: "true"
+...
+spec:
+  type: LoadBalancer
+...
+```
+This example publishes the service using the name foo which will result in the names
+foo.foospace.local, foo-foospace.local and, because we have specified the additional
+annotation foo.local is also published (unnecessary if using the global option).
+
+We urge you to test with the default behaviours for Services and Ingress before using these
+annotations as the automatic nature of external-mdns is good enough for most use cases.
+
+
 ## Deploying External-mDNS
 
 External-mDNS is configured using argument flags. Most flags can be replaced

--- a/main.go
+++ b/main.go
@@ -135,29 +135,27 @@ func constructRecords(r resource.Resource) []string {
 
 		var recordType string
 		if ip.To4() != nil {
-			if exposeIPv4 == false {
+			if !exposeIPv4 {
 				continue
 			}
 			recordType = "A"
 		} else {
-			if exposeIPv6 == false {
+			if !exposeIPv6 {
 				continue
 			}
 			recordType = "AAAA"
 		}
 
-		// Publish records resources as <name>.<namespace>.local
-		// Ensure corresponding PTR records map to this hostname
-		records = append(records, fmt.Sprintf("%s.%s.local. %d IN %s %s", r.Name, r.Namespace, recordTTL, recordType, ip))
-		if reverseIP != "" {
-			records = append(records, fmt.Sprintf("%s %d IN PTR %s.%s.local.", reverseIP, recordTTL, r.Name, r.Namespace))
-		}
-
-		// Publish records resources as <name>-<namespace>.local
+		// Publish records resources as <name>.<namespace>.local and as <name>-<namespace>.local
 		// Because Windows does not support subdomains resolution via mDNS and uses regular DNS query instead.
-		records = append(records, fmt.Sprintf("%s-%s.local. %d IN %s %s", r.Name, r.Namespace, recordTTL, recordType, ip))
-		if reverseIP != "" {
-			records = append(records, fmt.Sprintf("%s %d IN PTR %s-%s.local.", reverseIP, recordTTL, r.Name, r.Namespace))
+		// Ensure corresponding PTR records map to this hostname
+		for _, name := range r.Names {
+			records = append(records, fmt.Sprintf("%s.%s.local. %d IN %s %s", name, r.Namespace, recordTTL, recordType, ip))
+			records = append(records, fmt.Sprintf("%s-%s.local. %d IN %s %s", name, r.Namespace, recordTTL, recordType, ip))
+			if reverseIP != "" {
+				records = append(records, fmt.Sprintf("%s %d IN PTR %s.%s.local.", reverseIP, recordTTL, name, r.Namespace))
+				records = append(records, fmt.Sprintf("%s %d IN PTR %s-%s.local.", reverseIP, recordTTL, name, r.Namespace))
+			}
 		}
 
 		// Publish services without the name in the namespace if any of the following
@@ -166,9 +164,11 @@ func constructRecords(r resource.Resource) []string {
 		// 2. The -without-namespace flag is equal to true
 		// 3. The record to be published is from an Ingress with a defined hostname
 		if r.Namespace == defaultNamespace || withoutNamespace || r.SourceType == "ingress" {
-			records = append(records, fmt.Sprintf("%s.local. %d IN %s %s", r.Name, recordTTL, recordType, ip))
-			if reverseIP != "" {
-				records = append(records, fmt.Sprintf("%s %d IN PTR %s.local.", reverseIP, recordTTL, r.Name))
+			for _, name := range r.Names {
+				records = append(records, fmt.Sprintf("%s.local. %d IN %s %s", name, recordTTL, recordType, ip))
+				if reverseIP != "" {
+					records = append(records, fmt.Sprintf("%s %d IN PTR %s.local.", reverseIP, recordTTL, name))
+				}
 			}
 		}
 	}

--- a/mdns/mdns.go
+++ b/mdns/mdns.go
@@ -193,7 +193,7 @@ func (c *connector) readloop(in chan pkt) {
 		msg, addr, err := c.readMessage()
 		if err != nil {
 			// log dud packets
-			log.Printf("Could not read from %s: %s", c.UDPConn, err)
+			log.Printf("Could not read from %#v: %s", c.UDPConn, err)
 			continue
 		}
 		if len(msg.Question) > 0 {
@@ -216,7 +216,7 @@ func (c *connector) mainloop() {
 
 		msg.Answer = make([]dns.RR, 0) // some queries already have an answer, we should not answer them
 		for _, result := range c.query(msg.Question) {
-			if isLegacyUnicast == true {
+			if isLegacyUnicast {
 				// https://datatracker.ietf.org/doc/html/rfc6762#section-6.7
 				// The resource record TTL given in a legacy unicast response SHOULD NOT be greater than ten seconds
 				result.RR.Header().Ttl = 10
@@ -246,7 +246,7 @@ func (c *connector) mainloop() {
 			msg.UDPAddr = addr
 
 			// nuke questions
-			if isLegacyUnicast == false {
+			if !isLegacyUnicast {
 				msg.Question = nil
 			}
 

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -22,9 +22,10 @@ const (
 
 // Resource represents a resource to advertise over mDNS
 type Resource struct {
-	SourceType string
-	Action     string
-	IPs        []string
-	Names      []string
-	Namespace  string
+	SourceType       string
+	Action           string
+	IPs              []string
+	Names            []string
+	Namespace        string
+	WithoutNamespace bool // For service annotation override, not global flag
 }

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -25,6 +25,6 @@ type Resource struct {
 	SourceType string
 	Action     string
 	IPs        []string
-	Name       string
+	Names      []string
 	Namespace  string
 }

--- a/source/ingress.go
+++ b/source/ingress.go
@@ -135,7 +135,7 @@ func (i *IngressSource) buildRecords(obj interface{}, action string) ([]resource
 		advertiseObj := resource.Resource{
 			SourceType: "ingress",
 			Action:     action,
-			Name:       hostname,
+			Names:      []string{hostname},
 			Namespace:  ingress.Namespace,
 			IPs:        ipFields,
 		}

--- a/source/service.go
+++ b/source/service.go
@@ -16,6 +16,7 @@ package source
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/blake/external-mdns/resource"
 	corev1 "k8s.io/api/core/v1"
@@ -96,7 +97,16 @@ func (s *ServiceSource) buildRecord(obj interface{}, action string) (resource.Re
 		return advertiseObj, nil
 	}
 
-	advertiseObj.Names = []string{service.Name}
+	if hostnames, ok := service.Annotations["external-mdns.blakecovarrubias.com/hostnames"]; ok {
+		names := strings.Split(hostnames, ",")
+		for i := range names {
+			names[i] = strings.TrimSpace(names[i])
+		}
+		advertiseObj.Names = names
+	} else {
+		advertiseObj.Names = []string{service.Name}
+	}
+
 	advertiseObj.Namespace = service.Namespace
 	advertiseObj.IPs = []string{}
 

--- a/source/service.go
+++ b/source/service.go
@@ -46,7 +46,9 @@ func (s *ServiceSource) onAdd(obj interface{}) {
 	advertiseResource, err := s.buildRecord(obj, resource.Added)
 
 	if err != nil {
-		fmt.Printf("updating, %s", advertiseResource.Name)
+		for _, name := range advertiseResource.Names {
+			fmt.Printf("updating, %s", name)
+		}
 	}
 
 	if len(advertiseResource.IPs) == 0 {
@@ -60,7 +62,9 @@ func (s *ServiceSource) onDelete(obj interface{}) {
 	advertiseResource, err := s.buildRecord(obj, resource.Deleted)
 
 	if err != nil {
-		fmt.Printf("Error deleting, %s", advertiseResource.Name)
+		for _, name := range advertiseResource.Names {
+			fmt.Printf("Error deleting, %s", name)
+		}
 	}
 	s.notifyChan <- advertiseResource
 }
@@ -92,7 +96,7 @@ func (s *ServiceSource) buildRecord(obj interface{}, action string) (resource.Re
 		return advertiseObj, nil
 	}
 
-	advertiseObj.Name = service.Name
+	advertiseObj.Names = []string{service.Name}
 	advertiseObj.Namespace = service.Namespace
 	advertiseObj.IPs = []string{}
 

--- a/source/service.go
+++ b/source/service.go
@@ -106,6 +106,9 @@ func (s *ServiceSource) buildRecord(obj interface{}, action string) (resource.Re
 	} else {
 		advertiseObj.Names = []string{service.Name}
 	}
+	if withoutNS, ok := service.Annotations["external-mdns.blakecovarrubias.com/without-namespace"]; ok {
+		advertiseObj.WithoutNamespace = strings.EqualFold(withoutNS, "true")
+	}
 
 	advertiseObj.Namespace = service.Namespace
 	advertiseObj.IPs = []string{}


### PR DESCRIPTION
Based on the PR by @pl4nty this goes further.

# Hostnames annotation feature for services

Instead of a single hostname we add an annotation external-mdns.blakecovarrubias.com/hostnames which can take a comma separated string if present listing short hostnames.

e.g. 
## Advertising a single name
```
apiVersion: v1
kind: Service
metadata:
  name: myservice
  namespace: foospace
  annotations:
    external-mdns.blakecovarrubias.com/hostnames: foo
...
spec:
  type: LoadBalancer
...
```
Advertises the usual foo.foospace.local and foo-foospace.local names instead of myservice.foospace.local

## Advertising two names
```
apiVersion: v1
kind: Service
metadata:
  name: myservice
  namespace: foospace
  annotations:
    external-mdns.blakecovarrubias.com/hostnames: foo, bar
...
spec:
  type: LoadBalancer
...
```
Advertises the usual foo.foospace.local, foo-foospace.local, bar.foospace.local and bar-foospace.local names instead of myservice.foospace.local

# Selective without-namespace annotaton for services

Additionally an annotation external-mdns.blakecovarrubias.com/without-default can be used to conditionally advertise the name as <name>.local mimicing the global option but controlled for the specific service. This annotation is independent of the first annotation giving more flexibility in being able to use without-default less globally. I chose this name to be synonymous with the global value.

e.g.
## Use on it's own
```
apiVersion: v1
kind: Service
metadata:
  name: myservice
  namespace: foospace
  annotations:
    external-mdns.blakecovarrubias.com/without-namespace: "true"
...
spec:
  type: LoadBalancer
...
```
Causes myservice.local to be additionally advertised alongside myservice.foospace.local and myservice-foospace.local.

## Combined use with single hostname
```
apiVersion: v1
kind: Service
metadata:
  name: myservice
  namespace: foospace
  annotations:
    external-mdns.blakecovarrubias.com/hostnames: foo
    external-mdns.blakecovarrubias.com/without-namespace: "true"
...
spec:
  type: LoadBalancer
...
```
Advertises the usual foo.local, foo.foospace.local, foo-foospace.local names instead of myservice.foospace.local etc.

# Comments

Noting, my instinct would have been not to publish the namespaced based records when using without-namespace but to retain backward compatibility I chose not to change this behaviour and not to further increase the MR by adding a second control for this.

This should cater as a solid workaround for advertising TCP based ingress rules and services behind an Istio Gateway as mentioned in #21 

The PR is separated into 4 commits to ease review.
1. A Refactor tidy up and Adding the Facility to hold multiple names in the resource struct.
2. Implementation of the first annotation.
3. Implementation of the second annotation.
4. Documentation

Feedback please,  quite happy to alter as requested :)