### PR TITLE
[security] default to run as non root user nobody

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.16
+FROM --platform=$BUILDPLATFORM golang:1.16 as build
 LABEL maintainer="Blake Covarrubias <blake@covarrubi.as>" \
       org.opencontainers.image.authors="Blake Covarrubias <blake@covarrubi.as>" \
       org.opencontainers.image.description="Advertises records for Kubernetes resources over multicast DNS." \
@@ -14,11 +14,15 @@ ARG TARGETVARIANT
 ADD . /go/src/github.com/blake/external-mdns
 WORKDIR /go/src/github.com/blake/external-mdns
 
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=$(echo ${TARGETVARIANT} | cut -c2) \
+RUN mkdir -p /release/etc &&\
+    echo nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin > /release/etc/passwd &&\
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOARM=$(echo ${TARGETVARIANT} | cut -c2) \
     go build \
     -ldflags="-s -w" \
-    -o external-mdns .
+    -o /release/external-mdns .
+
 
 FROM scratch
-COPY --from=0 /go/src/github.com/blake/external-mdns/external-mdns /external-mdns
+COPY --from=build /release /
+USER nobody
 ENTRYPOINT ["/external-mdns"]

--- a/README.md
+++ b/README.md
@@ -50,9 +50,19 @@ spec:
       labels:
         app: external-mdns
     spec:
+      securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
       hostNetwork: true
+      serviceAccountName: external-mdns
       containers:
       - name: external-mdns
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         image: blakec/external-mdns:latest
         args:
         - -source=ingress
@@ -108,10 +118,19 @@ spec:
       labels:
         app: external-mdns
     spec:
+      securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
       hostNetwork: true
       serviceAccountName: external-mdns
       containers:
       - name: external-mdns
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         image: blakec/external-mdns:latest
         args:
         - -source=ingress


### PR DESCRIPTION
#23 Tested on it's own and integrated with my other PR implements a single line passwd file in the scratch container containing a nobody user and defaults to starting the user as that.

Layering is stil 1 layer, we simply construct a /release staging folder in the build container and copy that to root.

I use this same mechanism for my services that need connections to cloud services as golang doesn't have a trust chain in a scratch container unless there something well known on the image. I tend to copy /etc/ssl to the /release folder in the build stage to overcome this.

This allows a cleaner Deployment containing..

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: external-mdns
spec:
  strategy:
    type: Recreate
  selector:
    matchLabels:
      app: external-mdns
  template:
    metadata:
      labels:
        app: external-mdns
    spec:
      securityContext:     # POD rather than individual container
        runAsUser: 65534   # Already set in container but if vuln scans
        runAsGroup: 65534  # look they may only check here as this is authoritative
        runAsNonRoot: true
      hostNetwork: true
      serviceAccountName: external-mdns
      containers:
      - name: external-mdns
        securityContext:
          readOnlyRootFilesystem: true
          allowPrivilegeEscalation: false
          capabilities:
            drop: ["ALL"]
        image: blakec/external-mdns:latest
        args:
        - -source=ingress
        - -source=service
```