### PR TITLE
Use Kustomize for external-mdns deployment

### DIFF
--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -1,4 +1,4 @@
-
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,13 +21,13 @@ spec:
       hostNetwork: true
       serviceAccountName: external-mdns
       containers:
-      - name: external-mdns
-        securityContext:
-          readOnlyRootFilesystem: true
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
-        image: blakec/external-mdns:latest
-        args:
-        - -source=ingress
-        - -source=service
+        - name: external-mdns
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          image: blakec/external-mdns:latest
+          args:
+            - -source=ingress
+            - -source=service

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -1,0 +1,33 @@
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-mdns
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-mdns
+  template:
+    metadata:
+      labels:
+        app: external-mdns
+    spec:
+      securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+      hostNetwork: true
+      serviceAccountName: external-mdns
+      containers:
+      - name: external-mdns
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        image: blakec/external-mdns:latest
+        args:
+        - -source=ingress
+        - -source=service

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - service-account.yaml
+  - deployment.yaml

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 resources:
   - service-account.yaml
   - deployment.yaml

--- a/manifests/base/service-account.yaml
+++ b/manifests/base/service-account.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-mdns

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -1,0 +1,3 @@
+---
+resources:
+  - base/

--- a/manifests/rbac/cluster-role-binding.yaml
+++ b/manifests/rbac/cluster-role-binding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+ name: external-mdns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-mdns
+subjects:
+- kind: ServiceAccount
+  name: external-mdns
+  namespace: default

--- a/manifests/rbac/cluster-role-binding.yaml
+++ b/manifests/rbac/cluster-role-binding.yaml
@@ -2,12 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
- name: external-mdns-viewer
+  name: external-mdns-viewer
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: external-mdns
 subjects:
-- kind: ServiceAccount
-  name: external-mdns
-  namespace: default
+  - kind: ServiceAccount
+    name: external-mdns
+    namespace: default

--- a/manifests/rbac/cluster-role.yaml
+++ b/manifests/rbac/cluster-role.yaml
@@ -2,11 +2,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
- name: external-mdns
+  name: external-mdns
 rules:
-- apiGroups: [""]
-  resources: ["services"]
-  verbs: ["list", "watch"]
-- apiGroups: ["extensions","networking.k8s.io"]
-  resources: ["ingresses"]
-  verbs: ["list", "watch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["extensions", "networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["list", "watch"]

--- a/manifests/rbac/cluster-role.yaml
+++ b/manifests/rbac/cluster-role.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+ name: external-mdns
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["list", "watch"]
+- apiGroups: ["extensions","networking.k8s.io"]
+  resources: ["ingresses"]
+  verbs: ["list", "watch"]

--- a/manifests/rbac/kustomization.yaml
+++ b/manifests/rbac/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+namespace: default
+resources:
+  - ../base
+  - cluster-role.yaml
+  - cluster-role-binding.yaml


### PR DESCRIPTION
This commit moves the deployment manifests from the README to the manifests directory, allowing them to be deployed using Kustomize.

Fixes #27