### PR TITLE
Add CI tasks using GitHub Actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,10 @@
-build.sh
-Dockerfile
-LICENSE
-README.md
 .DS_Store
 .git/
+.github/
 .gitignore
 .vscode/
+CHANGELOG.md
+Dockerfile
+LICENSE
+manifests/
+README.md

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,146 @@
+---
+name: Continuous integration tasks
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  workflow_dispatch:  # Allow manual triggering of the workflow
+
+jobs:
+  golang-ci:
+    name: Lint Go code using golangci-lint
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Required: allow read access to the content for analysis.
+      contents: read
+      # Allow read access to pull request. Use with `only-new-issues` # option
+      pull-requests: read
+      # Allow write access to checks to allow the action to annotate code in the
+      # PR
+      checks: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          only-new-issues: true
+          problem-matchers: true
+
+  paths-filter:
+    name: Check if Dockerfile or Go code has changed
+    runs-on: ubuntu-latest
+    outputs:
+      modified: ${{ steps.filter.outputs.docker-or-gocode }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check if Dockerfile oer Go code has changed
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docker-or-gocode:
+              - Dockerfile'
+              - '*/**.go'
+
+  docker:
+    name: Build multi-arch container image
+    if: needs.paths-filter.outputs.modified == 'true'
+    runs-on: ubuntu-latest
+    # This job is dependent on the golang-ci job and paths-filter job.
+    # It will only run if the golang-ci job is successful and if the
+    # paths-filter job indicates that the Dockerfile or Go code have changed.
+    needs:
+      - golang-ci
+      - paths-filter
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: |
+            blakec/external-mdns
+            ghcr.io/${{ github.repository }}
+
+      - name: Build image and push to local image cache
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: >
+            linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6,linux/arm/v5
+          # Load the image into the local image cache instead of pushing it to
+          # a registry. This is useful for testing the image locally.
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  markdownlint:
+    name: Lint markdown files
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: tj-actions/changed-files@v45
+        id: changed-files
+        with:
+          files: '**/*.md'
+          separator: ","
+
+      - name: Lint markdown files
+        # This action will only run if there are changed files
+        # It will use the output from the previous step to determine if there
+        # are any changed files
+        # If there are no changed files, it will not run
+        # If there are changed files, it will run and lint them
+        # The output of this step will be the list of changed files
+        uses: DavidAnson/markdownlint-cli2-action@v19
+        if: steps.changed-files.outputs.any_changed == 'true'
+        with:
+          globs: ${{ steps.changed-files.outputs.all_changed_files }}
+          separator: ","
+
+  yamllint:
+    name: Lint YAML files
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if YAML files have changed
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            yaml:
+              - '**/*.yaml'
+              - '**/*.yml'
+
+      - name: Lint YAML files
+        if: steps.changes.outputs.yaml == 'true'
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          strict: true

--- a/.github/workflows/container_image.yaml
+++ b/.github/workflows/container_image.yaml
@@ -1,0 +1,131 @@
+---
+name: Build and push container image to image registries
+on:  # yamllint disable-line rule:truthy
+  push:
+    tags:
+      - "v*.*.*"
+  release:
+    types:
+      - published
+      - released
+  workflow_dispatch:  # Allow manual triggering of the workflow
+    inputs:
+      push_to_docker_hub:
+        description: 'Push image to Docker Hub'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+
+  push_to_registries:
+    name: Push image to container registries
+    runs-on: ubuntu-latest
+    env:
+      # The registries to push the image to
+      DOCKER_REGISTRY: docker.io
+      DOCKER_USERNAME: "${{ secrets.DOCKER_USERNAME }}"
+      GITHUB_REGISTRY: ghcr.io
+      # The name of the image to push
+      IMAGE_NAME: external-mdns
+
+    permissions:
+      # Permit generating an artifact attestation for the image
+      attestations: write
+      # Permits an action to list the commits
+      contents: read
+      # Fetch an OpenID Connect (OIDC) token
+      id-token: write
+      # Permit uploading and publishing packages on GitHub Packages.
+      packages: write
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64,arm
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@906ecf0fc0a80f9110f79d9e6c04b1080f4a2621
+        env:
+          # Attach metadata annotations to both the image index and the manifest
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest
+        with:
+          # yamllint disable rule:line-length
+          images: |
+            name=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }},enable=${{ github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && inputs.push_to_docker_hub == true) }}
+            name=${{ env.GITHUB_REGISTRY }}/${{ github.repository }}
+          # Disable generating the 'latest' tag on the image.
+          # It will be conditionally tagged later in the workflow.
+          flavor: |
+            latest=false
+          annotations: |
+            # The date the image was created
+            org.opencontainers.image.created={{date 'YYYY-MM-DDTHH:mm:ss.SSS[Z]'}}
+            org.opencontainers.image.revision={{sha}}
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.version={{tag}}
+          tags: |
+            # '{{version}}' results in a tag of '<major>.<minor>.<patch>'
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+            # Results in the image being tagged with same value as the Git tag
+            # (e.g.,'v<major>.<minor>.<patch>')
+            type=pep440,pattern={{raw}}
+
+            # set 'latest' tag on the image if the following conditions are met:
+            # 1. The event is a push
+            # 2. The base branch is the default branch
+            # 3. The GitHub reference starts with 'refs/tags/v'
+            # (i.e., the event is a tag release)
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.event.base_ref == format('refs/heads/{0}', github.event.repository.default_branch) && startsWith(github.ref, 'refs/tags/v') }}
+
+            # Tag the image with the commit SHA when manually triggered and is not
+            # a tag release. This is useful for testing and debugging.
+            type=sha,enable=${{ github.event_name == 'workflow_dispatch' && !startsWith(github.ref, 'ref/tags/v') }}
+          # yamllint enable rule:line-length
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        if: github.event_name != 'workflow_dispatch' || inputs.push_to_docker_hub == true  # yamllint disable-line rule:line-length
+        with:
+          registry: ${{ env.DOCKER_REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to GitHub Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.GITHUB_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push container image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: >
+            linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6,linux/arm/v5
+          push: ${{ github.event_name != 'pull_request' }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          # Use the same annotations as labels on the image
+          labels: ${{ steps.meta.outputs.annotations }}
+          tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.GITHUB_REGISTRY }}/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
 ## 0.5.0 (September 27, 2023)
 
 IMPROVEMENTS:

--- a/README.md
+++ b/README.md
@@ -27,21 +27,22 @@ advertised with a short name of `<hostname/service_name>.local`.
 ### Additional control for Services
 
 Service discovery is automatic, however, there are some scenarios where one may wish
-to directly control names used with a more general service i.e. the service might be
-in front of an Ingress Controller but the service you wish to use is not defined with
-an Ingress resource such as in the case of non http/https service with nginx.
+to directly control names used with a more general service i.e. the service might
+be in front of an Ingress Controller but the service you wish to use is not defined
+with an Ingress resource such as in the case of non http/https service with nginx.
 
-Other scenarios include non Ingress types that publish a variety of services and act as
-an ingress but have configurations far more complex than can be expressed by an Ingress
-resource e.g. Istio.
+Other scenarios include non Ingress types that publish a variety of services and
+act as an ingress but have configurations far more complex than can be expressed
+by an Ingress resource e.g. Istio.
 
-Additionally, one may wish to control in finer detail which services appear directly on
-.local MDNS advertisements without either moving services to the default namespace or
-enabling the global without-namespace flag.
+Additionally, one may wish to control in finer detail which services appear directly
+on .local MDNS advertisements without either moving services to the default namespace
+or enabling the global without-namespace flag.
 
-In this case Service annotations are possible as follows - these annotations have no effect
-if applied to an Ingress resource.
-```
+In this case Service annotations are possible as follows - these annotations have
+no effect if applied to an Ingress resource.
+
+```yaml
 apiVersion: v1
 kind: Service
 metadata:
@@ -55,13 +56,14 @@ spec:
   type: LoadBalancer
 ...
 ```
+
 This example publishes the service using the name foo which will result in the names
 foo.foospace.local, foo-foospace.local and, because we have specified the additional
 annotation foo.local is also published (unnecessary if using the global option).
 
-We urge you to test with the default behaviours for Services and Ingress before using these
-annotations as the automatic nature of external-mdns is good enough for most use cases.
-
+We urge you to test with the default behaviours for Services and Ingress before
+using these annotations as the automatic nature of external-mdns is good enough
+for most use cases.
 
 ## Deploying External-mDNS
 

--- a/main.go
+++ b/main.go
@@ -252,10 +252,10 @@ func main() {
 		switch src {
 		case "ingress":
 			ingressController := source.NewIngressWatcher(factory, namespace, notifyMdns)
-			go ingressController.Run(stopper)
+			go ingressController.Run(stopper) //nolint
 		case "service":
 			serviceController := source.NewServicesWatcher(factory, namespace, notifyMdns, publishInternal)
-			go serviceController.Run(stopper)
+			go serviceController.Run(stopper) //nolint
 		}
 	}
 


### PR DESCRIPTION
This PR introduces several CI tasks using GitHub Actions.

1. Linting of Go code using `golangci-lint`.
1. Multi-arch Docker image building.
1. Linting of Markdown files using `markdownlint`.
1. Automatic publishing of images to container registries (Docker Hub and GitHub Container registry).